### PR TITLE
Add APP_URL env in nginx.conf

### DIFF
--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -10,6 +10,7 @@ env GITHUB_REDIRECT_URL;
 env GOOGLE_CLIENT_ID;
 env GOOGLE_CLIENT_SECRET;
 env GOOGLE_REDIRECT_URL;
+env APP_URL;
 
 events {
   worker_connections 1024;


### PR DESCRIPTION
`APP_URL` is missing in nginx.conf. So that application can't use `os.getenv('APP_URL')`